### PR TITLE
Add collapsible controls and aircraft info panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flight-radar",
-  "version": "2.9.22",
+  "version": "2.9.23",
   "description": "Real-time 3D flight tracker with Material 3 Expressive design",
   "main": "main.js",
   "author": "Jonathan Birge",

--- a/shared/radar-ui.js
+++ b/shared/radar-ui.js
@@ -435,3 +435,25 @@ document.getElementById('toggle-rotate').addEventListener('change', (e) => {
     stopRotation();
   }
 });
+
+// ============================================================
+// Collapsible Panels
+// ============================================================
+
+// Controls panel collapse/expand
+const collapseControlsBtn = document.getElementById('btn-collapse-controls');
+if (collapseControlsBtn) {
+  collapseControlsBtn.addEventListener('click', () => {
+    const controls = document.getElementById('controls');
+    controls.classList.toggle('collapsed');
+  });
+}
+
+// Aircraft info panel collapse/expand
+const collapseInfoBtn = document.getElementById('btn-collapse-info');
+if (collapseInfoBtn) {
+  collapseInfoBtn.addEventListener('click', () => {
+    const infoPanel = document.getElementById('aircraft-info');
+    infoPanel.classList.toggle('collapsed');
+  });
+}

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -183,6 +183,41 @@ body {
   box-shadow: var(--md-elevation-2);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
+  transition: transform var(--md-motion-duration-medium) var(--md-motion-easing-standard),
+              opacity var(--md-motion-duration-medium) var(--md-motion-easing-standard);
+}
+
+/* Collapsible Controls Panel */
+.collapse-toggle {
+  position: absolute;
+  top: 50%;
+  right: -16px;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 48px;
+  background: var(--md-surface-container);
+  border: none;
+  border-radius: 0 var(--md-shape-sm) var(--md-shape-sm) 0;
+  color: var(--md-on-surface-variant);
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  box-shadow: var(--md-elevation-1);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  z-index: 1;
+}
+
+#controls.collapsed {
+  transform: translateX(calc(-100% - 16px));
+}
+
+#controls.collapsed .collapse-toggle {
+  right: -32px;
+  width: 32px;
 }
 
 .control-group {
@@ -449,6 +484,31 @@ input[type="range"]::-webkit-slider-thumb:hover {
 
 #aircraft-info.hidden {
   display: none;
+}
+
+/* Collapsible Aircraft Info Panel */
+.collapse-toggle-info {
+  position: absolute;
+  top: 16px;
+  right: 52px;
+  background: none;
+  border: none;
+  color: var(--md-on-surface-variant);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 4px;
+  min-height: 40px;
+  line-height: 40px;
+  transition: transform var(--md-motion-duration-short) var(--md-motion-easing-standard);
+}
+
+#aircraft-info.collapsed #info-details,
+#aircraft-info.collapsed #info-buttons {
+  display: none !important;
+}
+
+#aircraft-info.collapsed .collapse-toggle-info {
+  transform: rotate(-90deg);
 }
 
 #info-close,

--- a/src/help.html
+++ b/src/help.html
@@ -29,7 +29,9 @@
   </table>
 
   <h2>Controls Panel</h2>
-  <p>The controls panel is located at the bottom-left of the screen.</p>
+  <p>The controls panel is located at the bottom-left of the screen. Click the small
+    arrow tab on its right edge to collapse the panel out of the way; click it again
+    to expand it.</p>
 
   <h3>Toggles</h3>
   <ul>
@@ -178,6 +180,8 @@
   <h2>Aircraft Info Panel</h2>
   <p>
     Click on any aircraft to open the info panel in the top-right corner.
+    Click the small arrow next to the close button to minimize the panel,
+    rolling it up to show only the callsign header. Click it again to expand.
     It displays detailed information:
   </p>
   <ul>

--- a/src/index.html
+++ b/src/index.html
@@ -42,6 +42,7 @@
 
   <!-- Controls panel -->
   <div id="controls">
+    <button id="btn-collapse-controls" class="collapse-toggle" title="Collapse panel">&#x2039;</button>
     <div class="control-group">
       <label class="toggle-label">
         <input type="checkbox" id="toggle-aircraft">
@@ -111,6 +112,7 @@
   <!-- Selected aircraft info panel -->
   <div id="aircraft-info" class="hidden">
     <button id="info-close" class="scope-btn">&times;</button>
+    <button id="btn-collapse-info" class="collapse-toggle-info" title="Minimize">&#x25BE;</button>
     <div id="info-callsign">---</div>
     <div id="info-details"></div>
     <div id="info-buttons" class="hidden">

--- a/web/index.html
+++ b/web/index.html
@@ -7,10 +7,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,100..1000&display=swap">
-  <link rel="stylesheet" href="../vendor/cesium/Build/Cesium/Widgets/widgets.css?v=2.9.22">
-  <link rel="stylesheet" href="../shared/styles.css?v=2.9.22">
-  <link rel="stylesheet" href="styles.css?v=2.9.22">
-  <script src="../vendor/cesium/Build/Cesium/Cesium.js?v=2.9.22"></script>
+  <link rel="stylesheet" href="../vendor/cesium/Build/Cesium/Widgets/widgets.css?v=2.9.23">
+  <link rel="stylesheet" href="../shared/styles.css?v=2.9.23">
+  <link rel="stylesheet" href="styles.css?v=2.9.23">
+  <script src="../vendor/cesium/Build/Cesium/Cesium.js?v=2.9.23"></script>
 </head>
 <body>
   <div id="cesiumContainer"></div>
@@ -38,6 +38,7 @@
 
   <!-- Controls panel -->
   <div id="controls">
+    <button id="btn-collapse-controls" class="collapse-toggle" title="Collapse panel">&#x2039;</button>
     <div class="control-group">
       <label class="toggle-label">
         <input type="checkbox" id="toggle-aircraft">
@@ -116,6 +117,7 @@
   <!-- Selected aircraft info panel -->
   <div id="aircraft-info" class="hidden">
     <button id="info-close" class="scope-btn">&times;</button>
+    <button id="btn-collapse-info" class="collapse-toggle-info" title="Minimize">&#x25BE;</button>
     <div id="info-callsign">---</div>
     <div id="info-details"></div>
     <div id="info-buttons" class="hidden">
@@ -136,19 +138,19 @@
   </div>
 
   <!-- Shared modules -->
-  <script src="../shared/defaults.js?v=2.9.22"></script>
-  <script src="../shared/config.js?v=2.9.22"></script>
-  <script src="../shared/data.js?v=2.9.22"></script>
-  <script src="../shared/icons.js?v=2.9.22"></script>
-  <script src="../shared/settings.js?v=2.9.22"></script>
-  <script src="../shared/radar-core.js?v=2.9.22"></script>
-  <script src="../shared/radar-weather.js?v=2.9.22"></script>
-  <script src="../shared/radar-markers.js?v=2.9.22"></script>
-  <script src="../shared/radar-aircraft.js?v=2.9.22"></script>
-  <script src="../shared/radar-ui.js?v=2.9.22"></script>
-  <script src="../shared/radar-flightplan.js?v=2.9.22"></script>
-  <script src="../shared/radar.js?v=2.9.22"></script>
+  <script src="../shared/defaults.js?v=2.9.23"></script>
+  <script src="../shared/config.js?v=2.9.23"></script>
+  <script src="../shared/data.js?v=2.9.23"></script>
+  <script src="../shared/icons.js?v=2.9.23"></script>
+  <script src="../shared/settings.js?v=2.9.23"></script>
+  <script src="../shared/radar-core.js?v=2.9.23"></script>
+  <script src="../shared/radar-weather.js?v=2.9.23"></script>
+  <script src="../shared/radar-markers.js?v=2.9.23"></script>
+  <script src="../shared/radar-aircraft.js?v=2.9.23"></script>
+  <script src="../shared/radar-ui.js?v=2.9.23"></script>
+  <script src="../shared/radar-flightplan.js?v=2.9.23"></script>
+  <script src="../shared/radar.js?v=2.9.23"></script>
   <!-- Web-specific (API shim + settings panel + init) -->
-  <script src="app.js?v=2.9.22"></script>
+  <script src="app.js?v=2.9.23"></script>
 </body>
 </html>


### PR DESCRIPTION
Controls panel gets a tab on its right edge to collapse/expand it. Aircraft info panel gets a minimize button to roll it up to just the callsign header. Both use smooth CSS transitions.

Closes #38

https://claude.ai/code/session_01HyzD6WrEAymus2FCLG9ujg