### PR TITLE
Refine info panel UI and fix G-AIRMET snapshot handling

### DIFF
--- a/shared/radar-flightplan.js
+++ b/shared/radar-flightplan.js
@@ -1,6 +1,10 @@
 // Aircraft selection, info panel, flight plan search, and route display.
 // Depends on radar-core.js, radar-aircraft.js.
 
+function fmtZulu(iso) {
+  if (!iso || iso === '?') return '?';
+  return iso.replace('T', ' ').replace(/:\d{2}(\.\d+)?Z$/, 'Z');
+}
 
 // ============================================================
 // Aircraft Selection (click to inspect)
@@ -268,9 +272,9 @@ function showTurbInfo(entity) {
   }
 
   if (type === 'PIREP') {
-    document.getElementById('info-callsign').textContent = `PIREP — ${p.intensity.getValue()} TURB`;
+    document.getElementById('info-callsign').textContent = 'PIREP';
     document.getElementById('info-details').innerHTML = `
-      <div><span class="label">TYPE</span><span>Pilot Report</span></div>
+      <div><span class="label">TYPE</span><span>TURB</span></div>
       <div><span class="label">INTENSITY</span><span>${p.intensity.getValue()}</span></div>
       <div><span class="label">FL</span><span>${p.fltlvl.getValue()}</span></div>
       <div><span class="label">ACFT</span><span>${p.acType.getValue()}</span></div>
@@ -278,27 +282,25 @@ function showTurbInfo(entity) {
     `;
   } else if (type === 'SIGMET' || type === 'CONVECTIVE SIGMET') {
     const hazard = p.hazard.getValue();
-    const label = type === 'CONVECTIVE SIGMET' ? 'CONVECTIVE SIGMET' : 'SIGMET — TURBULENCE';
-    document.getElementById('info-callsign').textContent = label;
+    document.getElementById('info-callsign').textContent = 'SIGMET';
     const from = p.validFrom.getValue();
     const to = p.validTo.getValue();
     document.getElementById('info-details').innerHTML = `
-      <div><span class="label">TYPE</span><span>${type}</span></div>
       <div><span class="label">HAZARD</span><span>${hazard}</span></div>
       <div><span class="label">SEVERITY</span><span>${p.severity.getValue()}</span></div>
       <div><span class="label">BASE</span><span>${p.base.getValue()}</span></div>
       <div><span class="label">TOP</span><span>${p.top.getValue()}</span></div>
-      <div><span class="label">VALID</span><span>${from} — ${to}</span></div>
+      <div><span class="label">FROM</span><span>${fmtZulu(from)}</span></div>
+      <div><span class="label">TO</span><span>${fmtZulu(to)}</span></div>
     `;
   } else if (type === 'G-AIRMET') {
-    document.getElementById('info-callsign').textContent = `G-AIRMET — ${p.hazard.getValue()}`;
+    document.getElementById('info-callsign').textContent = 'AIRMET';
     document.getElementById('info-details').innerHTML = `
-      <div><span class="label">TYPE</span><span>G-AIRMET</span></div>
       <div><span class="label">HAZARD</span><span>${p.hazard.getValue()}</span></div>
       <div><span class="label">SEVERITY</span><span>${p.severity.getValue()}</span></div>
       <div><span class="label">BASE</span><span>${p.base.getValue()}</span></div>
       <div><span class="label">TOP</span><span>FL${p.top.getValue()}</span></div>
-      <div><span class="label">VALID</span><span>${p.validFrom.getValue()}</span></div>
+      <div><span class="label">VALID</span><span>${fmtZulu(p.validFrom.getValue())}</span></div>
     `;
   }
 }

--- a/shared/radar-markers.js
+++ b/shared/radar-markers.js
@@ -14,7 +14,7 @@ function getAirportColor() {
 
 function getAirportOutlineColor() {
   if (CONFIG.theme === 'light') {
-    return Cesium.Color.BLACK;
+    return Cesium.Color.fromCssColorString('#999999');
   }
   return Cesium.Color.fromCssColorString('#333333');
 }

--- a/shared/radar-weather.js
+++ b/shared/radar-weather.js
@@ -556,7 +556,7 @@ async function fetchPireps() {
           const cssColor = pirepCssColor(intensity);
           const icon = createPirepIcon(intensity, cssColor);
 
-          const obsTime = props.obsTime ? new Date(props.obsTime).toUTCString().slice(17, 25) + 'Z' : '?';
+          const obsTime = props.obsTime ? new Date(props.obsTime).toUTCString().slice(17, 22) + 'Z' : '?';
           const camH = viewer.camera.positionCartographic ? viewer.camera.positionCartographic.height : 1e7;
           const pirepDisplayCond = acDisplayCond || new Cesium.DistanceDisplayCondition(0, computeHorizonDist(camH));
           const entity = viewer.entities.add({
@@ -683,13 +683,8 @@ function _buildAirmetEntities(responses, targetArray, idPrefix) {
       const geom = f.geometry;
       if (!geom) continue;
       const ap = f.properties || {};
-      // Each snapshot is valid from validTime for 3 hours (until the next snapshot)
+      // G-AIRMETs are point-in-time snapshots, not intervals
       const validFrom = ap.validTime || null;
-      let validTo = null;
-      if (validFrom) {
-        const fromMs = new Date(validFrom).getTime();
-        if (!isNaN(fromMs)) validTo = new Date(fromMs + 3 * 60 * 60 * 1000).toISOString();
-      }
       const polygons = geom.type === 'Polygon' ? [geom.coordinates]
         : geom.type === 'MultiPolygon' ? geom.coordinates : [];
       for (const rings of polygons) {
@@ -713,7 +708,6 @@ function _buildAirmetEntities(responses, targetArray, idPrefix) {
             base: ap.base || '?',
             top: ap.top || '?',
             validFrom: validFrom || '?',
-            validTo: validTo || '?',
           },
         });
         targetArray.push(entity);
@@ -724,21 +718,47 @@ function _buildAirmetEntities(responses, targetArray, idPrefix) {
   return count;
 }
 
-// Fetch only the current G-AIRMET snapshot (forecast hour 0) for live display.
+// Fetch G-AIRMET snapshots for hours 0 and 3, keep the one closest to now.
+// G-AIRMETs are point-in-time snapshots issued every 6 hours; the fore=0 and
+// fore=3 snapshots may both be in the past, so we pick whichever is nearest.
 async function fetchAirmets() {
-  console.log('[Weather] Fetching G-AIRMETs (live, hour 0)...');
+  console.log('[Weather] Fetching G-AIRMETs (live, hours 0 & 3)...');
   try {
-    const resp = await fetch(awcUrl('gairmet?format=geojson&fore=0'))
-      .catch(err => { console.warn('[Weather] G-AIRMET fetch failed:', err.message); return null; });
-    if (!resp || !resp.ok) return;
-    const data = await resp.json();
-    const count = _buildAirmetEntities([data], airmetEntities, 'turb-airmet');
-    console.log(`[Weather] Added ${count} G-AIRMET polygons (live, hour 0)`);
+    const [resp0, resp3] = await Promise.all([
+      fetch(awcUrl('gairmet?format=geojson&fore=0'))
+        .catch(err => { console.warn('[Weather] G-AIRMET fore=0 fetch failed:', err.message); return null; }),
+      fetch(awcUrl('gairmet?format=geojson&fore=3'))
+        .catch(err => { console.warn('[Weather] G-AIRMET fore=3 fetch failed:', err.message); return null; }),
+    ]);
+    const snapshots = [];
+    for (const resp of [resp0, resp3]) {
+      if (resp && resp.ok) snapshots.push(await resp.json());
+    }
+    if (snapshots.length === 0) return;
+    // Pick the snapshot whose validTime is closest to now
+    const now = Date.now();
+    const best = snapshots.reduce((a, b) => {
+      const aTime = _snapshotTime(a);
+      const bTime = _snapshotTime(b);
+      return Math.abs(aTime - now) <= Math.abs(bTime - now) ? a : b;
+    });
+    const count = _buildAirmetEntities([best], airmetEntities, 'turb-airmet');
+    console.log(`[Weather] Added ${count} G-AIRMET polygons (nearest snapshot)`);
     // Apply altitude filter for new entities in live mode
     updateLiveAltitudeFilter(true);
   } catch (err) {
     console.warn('[Weather] Error fetching G-AIRMETs:', err);
   }
+}
+
+// Extract the validTime from the first feature in a G-AIRMET response as epoch ms.
+function _snapshotTime(resp) {
+  const features = resp && resp.features;
+  if (features && features.length > 0) {
+    const vt = (features[0].properties || {}).validTime;
+    if (vt) { const ms = new Date(vt).getTime(); if (!isNaN(ms)) return ms; }
+  }
+  return 0;
 }
 
 // Fetch all G-AIRMET forecast snapshots (hours 0,3,6,9,12) into the scrubbing array.
@@ -883,6 +903,9 @@ function isWeatherEntityVisible(entity, timeMs, altitudeFL) {
         const obsMs = new Date(isoStr).getTime();
         if (!isNaN(obsMs) && (obsMs > timeMs || timeMs - obsMs > PIREP_MAX_AGE_MS)) return false;
       }
+    } else if (type === 'G-AIRMET') {
+      // G-AIRMETs are point-in-time snapshots — handled by _filterNearestAirmetSnapshot
+      // so skip per-entity time filtering here (let the snapshot filter decide)
     } else {
       const from = p.validFrom ? p.validFrom.getValue() : null;
       const to = p.validTo ? p.validTo.getValue() : null;
@@ -927,13 +950,39 @@ function filterAllWeather(timeMs, altitudeFL) {
   for (const entity of sigmetEntities) {
     entity.show = isWeatherEntityVisible(entity, timeMs, altitudeFL);
   }
-  if (_scrubAirmetEntities.length > 0) {
-    for (const entity of _scrubAirmetEntities) {
-      entity.show = isWeatherEntityVisible(entity, timeMs, altitudeFL);
-    }
-  } else {
-    for (const entity of airmetEntities) {
-      entity.show = isWeatherEntityVisible(entity, timeMs, altitudeFL);
+  const airmetArr = _scrubAirmetEntities.length > 0 ? _scrubAirmetEntities : airmetEntities;
+  _filterNearestAirmetSnapshot(airmetArr, timeMs, altitudeFL);
+}
+
+// For G-AIRMET entities (point-in-time snapshots), show only entities from the
+// snapshot whose validTime is closest to timeMs. Then apply altitude filtering.
+function _filterNearestAirmetSnapshot(entities, timeMs, altitudeFL) {
+  if (entities.length === 0) return;
+  if (timeMs == null) {
+    // No time constraint — show all, just apply altitude filter
+    for (const e of entities) e.show = isWeatherEntityVisible(e, null, altitudeFL);
+    return;
+  }
+  // Group entities by validFrom and find the nearest snapshot
+  const byTime = new Map();
+  for (const e of entities) {
+    const vf = e.properties && e.properties.validFrom ? e.properties.validFrom.getValue() : null;
+    if (!byTime.has(vf)) byTime.set(vf, []);
+    byTime.get(vf).push(e);
+  }
+  let bestKey = null;
+  let bestDist = Infinity;
+  for (const key of byTime.keys()) {
+    if (!key || key === '?') continue;
+    const ms = new Date(key).getTime();
+    if (isNaN(ms)) continue;
+    const dist = Math.abs(ms - timeMs);
+    if (dist < bestDist) { bestDist = dist; bestKey = key; }
+  }
+  for (const [key, ents] of byTime) {
+    const isNearest = key === bestKey;
+    for (const e of ents) {
+      e.show = isNearest && isWeatherEntityVisible(e, null, altitudeFL);
     }
   }
 }

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -515,7 +515,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
 }
 
 #info-callsign {
-  font: var(--md-typescale-title-large);
+  font: var(--md-typescale-title-medium);
   font-weight: 500;
   color: var(--md-on-surface);
   margin-bottom: 8px;
@@ -538,6 +538,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
 
 #info-details .label {
   color: var(--md-on-surface-variant);
+  margin-right: 8px;
 }
 
 #info-buttons {


### PR DESCRIPTION
## Summary
- Shrink info panel title font from `title-large` (23px) to `title-medium` (17px)
- Simplify weather overlay titles: PIREP, SIGMET, AIRMET (remove redundant type/detail from titles)
- Add `margin-right` to info panel labels for better spacing
- Format Zulu times: drop seconds/fractions, replace `T` separator with space
- Split SIGMET valid times into separate FROM/TO lines
- Lighten airport icon outlines in light mode (black → gray)
- Fix G-AIRMET live fetch to request both `fore=0` and `fore=3`, picking the nearest snapshot
- Treat G-AIRMETs as point-in-time snapshots (not 3-hour intervals) per AWC documentation
- Add nearest-snapshot filtering for G-AIRMET scrubbing mode

Closes #110

## Test plan
- [ ] Verify info panel title is smaller and shows simplified names (PIREP, SIGMET, AIRMET)
- [ ] Verify label spacing in info panel looks correct
- [ ] Verify Zulu times display without seconds (e.g., `2026-03-22 14:30Z`)
- [ ] Verify SIGMET info panel shows separate FROM and TO lines
- [ ] Verify airport icons in light mode have gray outlines
- [ ] Verify G-AIRMETs display in live mode (turbulence overlays)
- [ ] Verify G-AIRMET scrubbing shows correct snapshot per timeline position

🤖 Generated with [Claude Code](https://claude.com/claude-code)