### PR TITLE
Fix 3D turbulence display slow loading

### DIFF
--- a/shared/radar-weather.js
+++ b/shared/radar-weather.js
@@ -282,7 +282,9 @@ async function fetchTurbImageDataUrl(level, dateSecs, opts) {
     // Fetch as blob so canvas won't be tainted by cross-origin
     const resp = await fetch(url);
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    if (resp.status === 204) throw new Error('No content (HTTP 204)');
     const blob = await resp.blob();
+    if (blob.size === 0) throw new Error('Empty response body');
     const blobUrl = URL.createObjectURL(blob);
 
     const img = await new Promise((resolve, reject) => {
@@ -1149,7 +1151,8 @@ function refreshTurbForecast() {
 // Compute the best turbulence forecast level based on the active flight plan.
 // If a flight plan with a filed altitude exists, snap to the nearest available FL.
 // Otherwise default to 'maxa' (MAX HI).
-window.TURB_LEVELS = [100, 130, 160, 180, 210, 240, 270, 300, 330, 360, 390, 420, 450];
+// Only levels that the AWC GTG API actually serves (others return 204 No Content).
+window.TURB_LEVELS = [180, 210, 240, 270, 300, 360, 420];
 
 function computeTurbLevel() {
   if (activeFlightPlan) {


### PR DESCRIPTION
## Summary
- Removes 6 invalid GTG flight levels (FL100, FL130, FL160, FL330, FL390, FL450) that return HTTP 204, cutting network requests nearly in half
- Adds early-exit guards in `fetchTurbImageDataUrl` for 204 responses and empty bodies to fail fast

Closes #143

## Test plan
- [ ] Enable 3D turbulence display and verify it loads significantly faster
- [ ] Confirm all 7 valid altitude layers render correctly
- [ ] Verify no console errors from the turbulence loading pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)