### PR TITLE
Add missing GTG turbulence levels FL120 and FL480

### DIFF
--- a/shared/radar-weather.js
+++ b/shared/radar-weather.js
@@ -1158,7 +1158,7 @@ function refreshTurbForecast() {
 // If a flight plan with a filed altitude exists, snap to the nearest available FL.
 // Otherwise default to 'maxa' (MAX HI).
 // Only levels that the AWC GTG API actually serves (others return 204 No Content).
-window.TURB_LEVELS = [180, 210, 240, 270, 300, 360, 420];
+window.TURB_LEVELS = [120, 180, 210, 240, 270, 300, 360, 420, 480];
 
 function computeTurbLevel() {
   if (activeFlightPlan) {


### PR DESCRIPTION
## Summary
- Added FL120 and FL480 to the `TURB_LEVELS` array in `shared/radar-weather.js`
- These are the only two levels the AWC GTG API serves that were missing from the array
- FL120 adds low-altitude turbulence coverage; FL480 adds the upper boundary

## Test plan
- [ ] Enable 3D turbulence view and verify FL120 and FL480 surfaces render correctly
- [ ] Verify turbulence level snapping works for altitudes near FL120 and FL480

🤖 Generated with [Claude Code](https://claude.com/claude-code)