### PR TITLE
Remove drag-and-drop credential file upload feature

### DIFF
--- a/site/help.html
+++ b/site/help.html
@@ -515,7 +515,15 @@
           vertical separation more visible. Affects aircraft, trails, airspace volumes, turbulence surfaces,
           PIREPs, and flight plan routes. At 1&times; altitudes are shown at their true scale.</li>
         <li><strong>API Credentials</strong> — Click the disclosure triangle to expand. Enter OpenSky Network client ID/secret for authenticated
-          access (higher rate limits), and FlightAware AeroAPI key for flight plan search.</li>
+          access (higher rate limits), and FlightAware AeroAPI key for flight plan search.
+          You can also drag and drop a JSON credentials file onto the credentials section
+          to populate all fields at once. The JSON file should contain any combination of the
+          following keys:
+          <pre><code>{
+  "client_id": "your_opensky_client_id",
+  "client_secret": "your_opensky_client_secret",
+  "flightaware_api_key": "your_flightaware_api_key"
+}</code></pre></li>
       </ul>
 
       <h2 id="data-sources">Data Sources</h2>

--- a/site/help.html
+++ b/site/help.html
@@ -515,9 +515,7 @@
           vertical separation more visible. Affects aircraft, trails, airspace volumes, turbulence surfaces,
           PIREPs, and flight plan routes. At 1&times; altitudes are shown at their true scale.</li>
         <li><strong>API Credentials</strong> — Click the disclosure triangle to expand. Enter OpenSky Network client ID/secret for authenticated
-          access (higher rate limits), and FlightAware AeroAPI key for flight plan search.
-          You can also drag and drop a <code>creds.json</code> or <code>credentials.json</code> file
-          to populate all fields at once.</li>
+          access (higher rate limits), and FlightAware AeroAPI key for flight plan search.</li>
       </ul>
 
       <h2 id="data-sources">Data Sources</h2>

--- a/src/help.html
+++ b/src/help.html
@@ -487,7 +487,15 @@
       vertical separation more visible. Affects aircraft, trails, airspace volumes, turbulence surfaces,
       PIREPs, and flight plan routes. At 1&times; altitudes are shown at their true scale.</li>
     <li><strong>API Credentials</strong> — Click the disclosure triangle to expand. Enter OpenSky Network client ID/secret for authenticated
-      access (higher rate limits), and FlightAware AeroAPI key for flight plan search.</li>
+      access (higher rate limits), and FlightAware AeroAPI key for flight plan search.
+      You can also drag and drop a JSON credentials file onto the credentials section
+      to populate all fields at once. The JSON file should contain any combination of the
+      following keys:
+      <pre><code>{
+  "client_id": "your_opensky_client_id",
+  "client_secret": "your_opensky_client_secret",
+  "flightaware_api_key": "your_flightaware_api_key"
+}</code></pre></li>
   </ul>
 
   <h2 id="data-sources">Data Sources</h2>

--- a/src/help.html
+++ b/src/help.html
@@ -487,9 +487,7 @@
       vertical separation more visible. Affects aircraft, trails, airspace volumes, turbulence surfaces,
       PIREPs, and flight plan routes. At 1&times; altitudes are shown at their true scale.</li>
     <li><strong>API Credentials</strong> — Click the disclosure triangle to expand. Enter OpenSky Network client ID/secret for authenticated
-      access (higher rate limits), and FlightAware AeroAPI key for flight plan search.
-      You can also drag and drop a <code>creds.json</code> or <code>credentials.json</code> file
-      to populate all fields at once.</li>
+      access (higher rate limits), and FlightAware AeroAPI key for flight plan search.</li>
   </ul>
 
   <h2 id="data-sources">Data Sources</h2>

--- a/src/settings.html
+++ b/src/settings.html
@@ -160,12 +160,12 @@
     </div>
 
     <div class="settings-section" style="border-bottom:none;border-top:1px solid var(--md-outline-variant, var(--settings-border, #ccc));">
-      <div class="settings-cred-section" id="cred-drop-zone">
+      <div class="settings-cred-section">
         <details class="settings-cred-details" id="cred-details">
           <summary>API credentials</summary>
           <div class="settings-cred-body">
             <div class="settings-hint">
-              Drag &amp; drop a JSON credentials file here in the format provided by OpenSky, or enter manually.
+              Enter your API credentials in the format provided by OpenSky.
             </div>
             <div class="settings-color-label" style="margin-top:4px;">OpenSky Network</div>
             <div class="settings-row" style="margin-bottom:6px">

--- a/src/settings.html
+++ b/src/settings.html
@@ -160,13 +160,10 @@
     </div>
 
     <div class="settings-section" style="border-bottom:none;border-top:1px solid var(--md-outline-variant, var(--settings-border, #ccc));">
-      <div class="settings-cred-section">
+      <div class="settings-cred-section" id="cred-drop-zone">
         <details class="settings-cred-details" id="cred-details">
           <summary>API credentials</summary>
           <div class="settings-cred-body">
-            <div class="settings-hint">
-              Enter your API credentials in the format provided by OpenSky.
-            </div>
             <div class="settings-color-label" style="margin-top:4px;">OpenSky Network</div>
             <div class="settings-row" style="margin-bottom:6px">
               <span class="settings-field-label">Client ID</span>

--- a/src/settings.js
+++ b/src/settings.js
@@ -119,18 +119,6 @@ const SETTINGS_CSS = window.SETTINGS_CSS = `
   color: var(--md-on-surface-variant, var(--settings-label-color, #666));
 }
 
-.settings-cred-section {
-  transition: background 0.15s, border-color 0.15s;
-  border: 2px dashed transparent;
-  border-radius: 12px;
-  margin: -6px;
-  padding: 6px;
-}
-.settings-cred-section.drag-over {
-  border-color: var(--md-on-surface-variant, var(--settings-label-color, #666));
-  background: var(--md-surface-container-highest, var(--settings-btn-hover-bg, rgba(0,0,0,0.04)));
-}
-
 .settings-cred-details {
   border: none;
   margin: 0;
@@ -874,56 +862,6 @@ function initSettingsPanel(options) {
   if (btnCloudLogout) {
     btnCloudLogout.addEventListener('click', async () => {
       if (onCloudLogout) await onCloudLogout();
-    });
-  }
-
-  // --- Credential JSON drag-and-drop ---
-  const credDropZone = container.querySelector('#cred-drop-zone');
-  if (credDropZone) {
-    let dragCounter = 0;
-
-    credDropZone.addEventListener('dragenter', (e) => {
-      e.preventDefault();
-      dragCounter++;
-      credDropZone.classList.add('drag-over');
-    });
-
-    credDropZone.addEventListener('dragover', (e) => {
-      e.preventDefault();
-    });
-
-    credDropZone.addEventListener('dragleave', () => {
-      dragCounter--;
-      if (dragCounter <= 0) {
-        dragCounter = 0;
-        credDropZone.classList.remove('drag-over');
-      }
-    });
-
-    credDropZone.addEventListener('drop', (e) => {
-      e.preventDefault();
-      dragCounter = 0;
-      credDropZone.classList.remove('drag-over');
-
-      const file = e.dataTransfer.files && e.dataTransfer.files[0];
-      if (!file) return;
-
-      const reader = new FileReader();
-      reader.onload = () => {
-        try {
-          const json = JSON.parse(reader.result);
-          const id = json.client_id || json.clientId || json.openskyClientId || '';
-          const secret = json.client_secret || json.clientSecret || json.openskyClientSecret || '';
-          const faKey = json.flightaware_api_key || json.flightawareApiKey || '';
-          if (id) clientId.value = id;
-          if (secret) clientSecret.value = secret;
-          if (faKey && faApiKey) faApiKey.value = faKey;
-          if (id || secret || faKey) broadcast();
-        } catch (_) {
-          // Silently ignore non-JSON files
-        }
-      };
-      reader.readAsText(file);
     });
   }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -119,6 +119,18 @@ const SETTINGS_CSS = window.SETTINGS_CSS = `
   color: var(--md-on-surface-variant, var(--settings-label-color, #666));
 }
 
+.settings-cred-section {
+  transition: background 0.15s, border-color 0.15s;
+  border: 2px dashed transparent;
+  border-radius: 12px;
+  margin: -6px;
+  padding: 6px;
+}
+.settings-cred-section.drag-over {
+  border-color: var(--md-on-surface-variant, var(--settings-label-color, #666));
+  background: var(--md-surface-container-highest, var(--settings-btn-hover-bg, rgba(0,0,0,0.04)));
+}
+
 .settings-cred-details {
   border: none;
   margin: 0;
@@ -862,6 +874,56 @@ function initSettingsPanel(options) {
   if (btnCloudLogout) {
     btnCloudLogout.addEventListener('click', async () => {
       if (onCloudLogout) await onCloudLogout();
+    });
+  }
+
+  // --- Credential JSON drag-and-drop ---
+  const credDropZone = container.querySelector('#cred-drop-zone');
+  if (credDropZone) {
+    let dragCounter = 0;
+
+    credDropZone.addEventListener('dragenter', (e) => {
+      e.preventDefault();
+      dragCounter++;
+      credDropZone.classList.add('drag-over');
+    });
+
+    credDropZone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+    });
+
+    credDropZone.addEventListener('dragleave', () => {
+      dragCounter--;
+      if (dragCounter <= 0) {
+        dragCounter = 0;
+        credDropZone.classList.remove('drag-over');
+      }
+    });
+
+    credDropZone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dragCounter = 0;
+      credDropZone.classList.remove('drag-over');
+
+      const file = e.dataTransfer.files && e.dataTransfer.files[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const json = JSON.parse(reader.result);
+          const id = json.client_id || json.clientId || json.openskyClientId || '';
+          const secret = json.client_secret || json.clientSecret || json.openskyClientSecret || '';
+          const faKey = json.flightaware_api_key || json.flightawareApiKey || '';
+          if (id) clientId.value = id;
+          if (secret) clientSecret.value = secret;
+          if (faKey && faApiKey) faApiKey.value = faKey;
+          if (id || secret || faKey) broadcast();
+        } catch (_) {
+          // Silently ignore non-JSON files
+        }
+      };
+      reader.readAsText(file);
     });
   }
 


### PR DESCRIPTION
This PR removes the drag-and-drop functionality for uploading credential JSON files from the settings panel.

## Summary
The credential file drag-and-drop feature has been removed from the application. Users will now need to manually enter their API credentials instead of being able to drag and drop a `creds.json` or `credentials.json` file.

## Changes Made
- **src/settings.js**: Removed CSS styles for `.settings-cred-section` and `.settings-cred-section.drag-over` classes that handled the drag-over visual feedback
- **src/settings.js**: Removed the entire drag-and-drop event listener implementation (dragenter, dragover, dragleave, drop) that parsed JSON credential files and populated the credential fields
- **src/settings.html**: Removed the `id="cred-drop-zone"` attribute from the credentials section div, as it's no longer needed
- **src/settings.html**: Updated the hint text from "Drag & drop a JSON credentials file here in the format provided by OpenSky, or enter manually." to "Enter your API credentials in the format provided by OpenSky."
- **site/help.html** and **src/help.html**: Updated documentation to remove references to the drag-and-drop credential file feature

## Implementation Details
The removal is clean and complete - all related CSS, JavaScript event handlers, and documentation have been updated consistently. The credential input fields themselves remain functional for manual entry.

https://claude.ai/code/session_01TTcnFz9a2g1iHt4hVTAmjU