### PR TITLE
Replace OpenTopoMap with three Esri basemap layers

### DIFF
--- a/src/help.html
+++ b/src/help.html
@@ -113,7 +113,7 @@
   <h3 id="dropdowns">Dropdowns</h3>
   <ul>
     <li><strong>Map</strong> — Base map layer. Choose from Simple, Simple (Labels), Gray Canvas,
-      Satellite, OpenStreetMap, Topographic,
+      Satellite, OpenStreetMap, Shaded Relief, ESRI Roadmap, ESRI Topographic, NatGeo,
       or VFRMap.com VFR/IFR charts with multi-zoom support.</li>
   </ul>
 
@@ -404,7 +404,9 @@
     <tr><td>Satellite (Labels)</td><td>Satellite imagery with place names and boundary labels overlaid</td></tr>
     <tr><td>OpenStreetMap</td><td>Standard OpenStreetMap road and street map</td></tr>
     <tr><td>Shaded Relief</td><td>Esri World Shaded Relief &mdash; hill shading without roads or labels</td></tr>
-    <tr><td>Topographic</td><td>OpenTopoMap with contour lines and hill shading</td></tr>
+    <tr><td>ESRI Roadmap</td><td>Esri World Street Map &mdash; detailed road and street map</td></tr>
+    <tr><td>ESRI Topographic</td><td>Esri World Topo Map &mdash; topographic basemap with contours, shaded relief, and labels</td></tr>
+    <tr><td>NatGeo</td><td>Esri National Geographic World Map &mdash; cartographic style basemap</td></tr>
     <tr><td>VFR Sectional</td><td>VFRMap.com hybrid VFR &mdash; shows WAC at low zoom, Sectional at mid, TAC at high; upscaled beyond native zoom</td></tr>
     <tr><td>IFR Low</td><td>VFRMap.com IFR Low Altitude Enroute; upscaled beyond native zoom</td></tr>
     <tr><td>IFR High</td><td>VFRMap.com IFR High Altitude Enroute; upscaled beyond native zoom</td></tr>

--- a/src/index.html
+++ b/src/index.html
@@ -97,7 +97,9 @@
             <div class="map-layer-option" data-value="satLabels">Satellite (Labels)</div>
             <div class="map-layer-option" data-value="osm">OpenStreetMap</div>
             <div class="map-layer-option" data-value="relief">Shaded Relief</div>
-            <div class="map-layer-option" data-value="topo">Topographic</div>
+            <div class="map-layer-option" data-value="esriRoadmap">ESRI Roadmap</div>
+            <div class="map-layer-option" data-value="esriTopo">ESRI Topographic</div>
+            <div class="map-layer-option" data-value="esriNatGeo">NatGeo</div>
             <div class="map-layer-option" data-value="vfrHybrid">VFR Sectional</div>
             <div class="map-layer-option" data-value="vfrIfrLow">IFR Low</div>
             <div class="map-layer-option" data-value="vfrIfrHigh">IFR High</div>

--- a/src/radar-core.js
+++ b/src/radar-core.js
@@ -247,12 +247,27 @@ function makeShadedReliefTiles() {
   });
 }
 
-function makeTopoTiles() {
+function makeEsriRoadmapTiles() {
   return new Cesium.UrlTemplateImageryProvider({
-    url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
-    subdomains: ['a', 'b', 'c'],
-    credit: new Cesium.Credit('OpenTopoMap, OpenStreetMap contributors'),
-    minimumLevel: 0, maximumLevel: 17,
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',
+    credit: new Cesium.Credit('Esri, HERE, Garmin, FAO, NOAA, USGS'),
+    minimumLevel: 0, maximumLevel: 19,
+  });
+}
+
+function makeEsriTopoTiles() {
+  return new Cesium.UrlTemplateImageryProvider({
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
+    credit: new Cesium.Credit('Esri, HERE, Garmin, FAO, NOAA, USGS, OpenStreetMap contributors'),
+    minimumLevel: 0, maximumLevel: 19,
+  });
+}
+
+function makeEsriNatGeoTiles() {
+  return new Cesium.UrlTemplateImageryProvider({
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}',
+    credit: new Cesium.Credit('Esri, National Geographic, DeLorme, HERE'),
+    minimumLevel: 0, maximumLevel: 16,
   });
 }
 
@@ -312,7 +327,9 @@ async function makeMapTiles(layerId) {
     case 'satLabels':  return makeSatelliteTiles();
     case 'osm':        return makeOsmTiles();
     case 'relief':     return makeShadedReliefTiles();
-    case 'topo':       return makeTopoTiles();
+    case 'esriRoadmap': return makeEsriRoadmapTiles();
+    case 'esriTopo':   return makeEsriTopoTiles();
+    case 'esriNatGeo': return makeEsriNatGeoTiles();
     case 'vfrHybrid':  return makeVfrMapTiles('vfrc', 12);
     case 'vfrIfrLow':  return makeVfrMapTiles('ifrlc', 11);
     case 'vfrIfrHigh': return makeVfrMapTiles('ehc', 10);


### PR DESCRIPTION
## Summary
This PR replaces the single OpenTopoMap topographic layer with three Esri basemap options, providing users with more variety in map styles and better coverage.

## Key Changes
- **Removed OpenTopoMap layer**: Replaced `makeTopoTiles()` function that provided OpenTopoMap tiles
- **Added three new Esri basemap layers**:
  - `makeEsriRoadmapTiles()`: Esri World Street Map for detailed road/street visualization
  - `makeEsriTopoTiles()`: Esri World Topo Map with contours, shaded relief, and labels
  - `makeEsriNatGeoTiles()`: Esri National Geographic World Map with cartographic styling
- **Updated map layer selector**: Changed UI options in `index.html` from single "Topographic" to three Esri options
- **Updated documentation**: Modified `help.html` to reflect the new map layer options and their descriptions
- **Updated layer routing**: Modified the `makeMapTiles()` switch statement to route to the new Esri tile functions

## Implementation Details
- All three new Esri layers use the ArcGIS REST services endpoint with proper tile coordinate ordering (`{z}/{y}/{x}`)
- Maximum zoom levels adjusted per layer: Roadmap and Topo support level 19, NatGeo supports level 16
- Proper attribution credits included for each Esri layer and their data providers
- Maintains backward compatibility with existing layer selection logic

https://claude.ai/code/session_01U66JxKe4W59etyUyy79H8b